### PR TITLE
Merge development into master

### DIFF
--- a/watchdogs/io/EncodingViewer.py
+++ b/watchdogs/io/EncodingViewer.py
@@ -133,9 +133,9 @@ class EncodingViewer(File):
         parser = self.parser;
         required = parser.add_argument_group("Required arguments");
         required.add_argument("-if", "--input-file", required=True, help="Specify the input file to read from.", type=str, metavar="");
-        required.add_argument("-ef", "--encode-from", required=True, help="The encoding type to encode from.", type=int, metavar="");
+        required.add_argument("-ef", "--encode-from", required=True, help="The encoding type to encode from. This value must be a numerical value from the encoding list.", type=int, metavar="");
         parser.add_argument("-of", "--output-file", help="Specify the output file to write to.", type=str, metavar="");
-        parser.add_argument("-et", "--encode-to", help="The encoding type to encode to. Default is utf-8", type=int, metavar="", default=85);
+        parser.add_argument("-et", "--encode-to", help="The encoding type to encode to. This value must be a numerical value from the encoding list. Default is number 85 - utf-8", type=int, metavar="", default=85);
         parser.add_argument("-le", "--list-encodings", action="version", help="Conversion types.", version=self.getEncodings());
         parser.add_argument("-v", "--version", action="version", help="Show version", version="Encoding Viewer version: {}".format(EncodingViewer.VERSION));
         parser.add_argument("-h", "--help", action="help", help="Show this help message");

--- a/watchdogs/web/FileFuzzer.py
+++ b/watchdogs/web/FileFuzzer.py
@@ -37,6 +37,8 @@ class FileFuzzer(File):
         self.filterIn = "";
         self.filterOut = "";
         self.showResponse = False;
+        self.showFuzz = False;
+        self.FuzzText = "";
         
     def __setattr__(self, name, value):
         super(FileFuzzer, self).__setattr__(name, value);
@@ -64,6 +66,7 @@ class FileFuzzer(File):
         parser.add_argument("-hp", "--http-proxy", help="Specify a proxy.", type=str, metavar="");
         parser.add_argument("-hs", "--https-proxy", help="Specify an ssl proxy", type=str, metavar="");
         parser.add_argument("-sr", "--show-response", action="store_true", help="Shows the response body");
+        parser.add_argument("-sf", "--show-fuzz", action="store_true", help="Shows the fuzz text used in the request");
         parser.add_argument("-v", "--version", action="version", help="Show version", version="File Fuzzer version: {}".format(FileFuzzer.VERSION));
         parser.add_argument("-h", "--help", action="help", help="Show this help message");
         self.args = parser.parse_args();
@@ -258,6 +261,8 @@ class FileFuzzer(File):
             return;
         
         responseString = "Response status: {} - Response length: {}".format(responseStatus, responseLength);
+        if(self.showFuzz):
+            responseString += " - Fuzz text: {}".format(self.FuzzText);
         if(self.showResponse):
             responseString = "\r\nResponse body: {}\r\n".format(responseSoup) + responseString;
         
@@ -283,6 +288,7 @@ class FileFuzzer(File):
                 attrKey = list(keys)[0];
                 key = self.fuzzLocator[list(keys)[0]];
                 self.swapFuzz(FUZZ, line.rstrip(), attrKey, key);
+                self.FuzzText = line.rstrip();
             self.sendRequest();
             self.swapFuzz(line.rstrip(), FUZZ, attrKey, key);
     


### PR DESCRIPTION
1.Added the -sf --show-fuzz flag option to display the used fuzz text in the response along with the status code and length for the FileFuzzer module. 
2.Update the Encoding viewer module's help message.